### PR TITLE
Use API key with cache service

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -27,12 +27,13 @@ type mockBody struct {
 func TestNewClient(t *testing.T) {
 	Convey("when a new client instance is created", t, func() {
 
-		actual := NewClient("baseurl", "/path", &broker.CacheBroker{}, &http.Client{}, &mocking.MockLogger{})
+		actual := NewClient("baseurl", "/path", "token", &broker.CacheBroker{}, &http.Client{}, &mocking.MockLogger{})
 
 		Convey("then a new client should be created", func() {
 			So(actual, ShouldNotBeNil)
 			So(actual.baseurl, ShouldEqual, "baseurl")
 			So(actual.path, ShouldEqual, "/path")
+			So(actual.token, ShouldEqual, "token")
 			So(actual.broker, ShouldResemble, &broker.CacheBroker{})
 			So(actual.httpClient, ShouldResemble, &http.Client{})
 		})
@@ -41,20 +42,23 @@ func TestNewClient(t *testing.T) {
 
 func TestPublishToBroker(t *testing.T) {
 	Convey("given a mock broker and http client is called", t, func() {
+		expectedRequest, _ := http.NewRequest("GET", "baseurl/path", nil)
+		expectedRequest.SetBasicAuth("token", "")
+
 		publisher := &mockBroker{}
 		publisher.On("Publish", mock.Anything).Return()
 
 		body := &mockBody{data: "Test Data \n"}
 
 		getter := &mockHttpClient{}
-		getter.On("Get", mock.Anything).Return(&http.Response{StatusCode: 200,
+		getter.On("Do", mock.Anything).Return(&http.Response{StatusCode: 200,
 			Body: body,
 		}, nil)
 
 		logger := &mocking.MockLogger{}
 		logger.On("Error", mock.Anything).Return(nil)
 
-		client := NewClient("baseurl", "/path", publisher, getter, logger)
+		client := NewClient("baseurl", "/path", "token", publisher, getter, logger)
 		client.wg = new(sync.WaitGroup)
 
 		Convey("When a new message is published from the cache broker", func() {
@@ -64,7 +68,7 @@ func TestPublishToBroker(t *testing.T) {
 			Convey("Then the message should be forwarded to the broker", func() {
 				So(status.Err, ShouldBeNil)
 				So(status.Code, ShouldEqual, 200)
-				So(getter.AssertCalled(t, "Get", "baseurl/path"), ShouldBeTrue)
+				So(getter.AssertCalled(t, "Do", expectedRequest), ShouldBeTrue)
 				So(publisher.AssertCalled(t, "Publish", "Test Data \n"), ShouldBeTrue)
 			})
 		})
@@ -73,20 +77,23 @@ func TestPublishToBroker(t *testing.T) {
 
 func TestSkipPublishingToBrokerIfZeroLengthMessage(t *testing.T) {
 	Convey("Given a mock broker and http client is called", t, func() {
+		expectedRequest, _ := http.NewRequest("GET", "baseurl/path", nil)
+		expectedRequest.SetBasicAuth("token", "")
+
 		publisher := &mockBroker{}
 		publisher.On("Publish", mock.Anything).Return()
 
 		body := &mockBody{data: "\n"}
 
 		getter := &mockHttpClient{}
-		getter.On("Get", mock.Anything).Return(&http.Response{StatusCode: 200,
+		getter.On("Do", mock.Anything).Return(&http.Response{StatusCode: 200,
 			Body: body,
 		}, nil)
 
 		logger := &mocking.MockLogger{}
 		logger.On("Error", mock.Anything).Return(nil)
 
-		client := NewClient("baseurl", "/path", publisher, getter, logger)
+		client := NewClient("baseurl", "/path", "token", publisher, getter, logger)
 		client.wg = new(sync.WaitGroup)
 
 		Convey("When a zero-length message is published by the cache service", func() {
@@ -96,7 +103,7 @@ func TestSkipPublishingToBrokerIfZeroLengthMessage(t *testing.T) {
 			Convey("Then the message should be discarded", func() {
 				So(status.Err, ShouldBeNil)
 				So(status.Code, ShouldEqual, 200)
-				So(getter.AssertCalled(t, "Get", "baseurl/path"), ShouldBeTrue)
+				So(getter.AssertCalled(t, "Do", expectedRequest), ShouldBeTrue)
 				So(publisher.AssertNotCalled(t, "Publish", mock.Anything), ShouldBeTrue)
 			})
 		})
@@ -105,25 +112,28 @@ func TestSkipPublishingToBrokerIfZeroLengthMessage(t *testing.T) {
 
 func TestDisconnectWhenFinishInvoked(t *testing.T) {
 	Convey("Given the client has connected to a service", t, func() {
+		expectedRequest, _ := http.NewRequest("GET", "baseurl/path", nil)
+		expectedRequest.SetBasicAuth("token", "")
+
 		publisher := &mockBroker{}
 		publisher.On("Publish", mock.Anything).Return()
 
 		getter := &mockHttpClient{}
-		getter.On("Get", mock.Anything).Return(&http.Response{StatusCode: 200,
+		getter.On("Do", mock.Anything).Return(&http.Response{StatusCode: 200,
 			Body: &mockBody{},
 		}, nil)
 
 		logger := &mocking.MockLogger{}
 		logger.On("Error", mock.Anything).Return(nil)
 
-		client := NewClient("baseurl", "/path", publisher, getter, logger)
+		client := NewClient("baseurl", "/path", "token", publisher, getter, logger)
 		status := client.Connect()
 		Convey("When the close method is invoked", func() {
 			client.Close()
 			Convey("Then the reader should be closed and no further processing should take place", func() {
 				So(status.Err, ShouldBeNil)
 				So(status.Code, ShouldEqual, 200)
-				So(getter.AssertCalled(t, "Get", "baseurl/path"), ShouldBeTrue)
+				So(getter.AssertCalled(t, "Do", expectedRequest), ShouldBeTrue)
 				So(publisher.AssertNotCalled(t, "Publish", mock.Anything), ShouldBeTrue)
 				So(client.closed, ShouldBeTrue)
 			})
@@ -133,11 +143,14 @@ func TestDisconnectWhenFinishInvoked(t *testing.T) {
 
 func TestReturnNon200ResponseCode(t *testing.T) {
 	Convey("Given the service will return HTTP 404 Not Found", t, func() {
+		expectedRequest, _ := http.NewRequest("GET", "baseurl/path", nil)
+		expectedRequest.SetBasicAuth("token", "")
+
 		publisher := &mockBroker{}
 		publisher.On("Publish", mock.Anything).Return()
 
 		getter := &mockHttpClient{}
-		getter.On("Get", mock.Anything).Return(&http.Response{StatusCode: 404,
+		getter.On("Do", mock.Anything).Return(&http.Response{StatusCode: 404,
 			Body: &mockBody{},
 		}, nil)
 
@@ -145,13 +158,13 @@ func TestReturnNon200ResponseCode(t *testing.T) {
 		logger.On("Error", mock.Anything).Return()
 		logger.On("Info", mock.Anything, mock.Anything).Return()
 
-		client := NewClient("baseurl", "/path", publisher, getter, logger)
+		client := NewClient("baseurl", "/path", "token", publisher, getter, logger)
 		Convey("When the client connects to the service", func() {
 			status := client.Connect()
 			Convey("Then the status code should be returned and no processing should be done", func() {
 				So(status.Err, ShouldBeNil)
 				So(status.Code, ShouldEqual, 404)
-				So(getter.AssertCalled(t, "Get", "baseurl/path"), ShouldBeTrue)
+				So(getter.AssertCalled(t, "Do", expectedRequest), ShouldBeTrue)
 				So(publisher.AssertNotCalled(t, "Publish", mock.Anything), ShouldBeTrue)
 				So(client.closed, ShouldBeTrue)
 			})
@@ -161,24 +174,27 @@ func TestReturnNon200ResponseCode(t *testing.T) {
 
 func TestReturnConnectionError(t *testing.T) {
 	Convey("Given the client will fail to connect to the service", t, func() {
+		expectedRequest, _ := http.NewRequest("GET", "baseurl/path", nil)
+		expectedRequest.SetBasicAuth("token", "")
+
 		expectedError := errors.New("something went wrong")
 		publisher := &mockBroker{}
 		publisher.On("Publish", mock.Anything).Return()
 
 		getter := &mockHttpClient{}
-		getter.On("Get", mock.Anything).Return(&http.Response{}, expectedError)
+		getter.On("Do", mock.Anything).Return(&http.Response{}, expectedError)
 
 		logger := &mocking.MockLogger{}
 		logger.On("Error", mock.Anything, mock.Anything).Return()
 		logger.On("Info", mock.Anything, mock.Anything).Return()
 
-		client := NewClient("baseurl", "/path", publisher, getter, logger)
+		client := NewClient("baseurl", "/path", "token", publisher, getter, logger)
 		Convey("When the client attempts to connect to the service", func() {
 			status := client.Connect()
 			Convey("Then the error should be returned and no processing should be done", func() {
 				So(status.Err, ShouldEqual, expectedError)
 				So(status.Code, ShouldEqual, 0)
-				So(getter.AssertCalled(t, "Get", "baseurl/path"), ShouldBeTrue)
+				So(getter.AssertCalled(t, "Do", expectedRequest), ShouldBeTrue)
 				So(logger.AssertCalled(t, "Error", expectedError, []log.Data(nil)), ShouldBeTrue)
 				So(publisher.AssertNotCalled(t, "Publish", mock.Anything), ShouldBeTrue)
 				So(client.closed, ShouldBeTrue)
@@ -189,20 +205,23 @@ func TestReturnConnectionError(t *testing.T) {
 
 func TestCallCacheServiceWithProvidedOffsetIfSetOffsetInvoked(t *testing.T) {
 	Convey("Given an offset has been specified", t, func() {
+		expectedRequest, _ := http.NewRequest("GET", "baseurl/path?timepoint=3", nil)
+		expectedRequest.SetBasicAuth("token", "")
+
 		publisher := &mockBroker{}
 		publisher.On("Publish", mock.Anything).Return()
 
 		body := &mockBody{data: "Test Data \n"}
 
 		getter := &mockHttpClient{}
-		getter.On("Get", mock.Anything).Return(&http.Response{StatusCode: 200,
+		getter.On("Do", mock.Anything).Return(&http.Response{StatusCode: 200,
 			Body: body,
 		}, nil)
 
 		logger := &mocking.MockLogger{}
 		logger.On("Error", mock.Anything).Return(nil)
 
-		client := NewClient("baseurl", "/path", publisher, getter, logger)
+		client := NewClient("baseurl", "/path", "token", publisher, getter, logger)
 		client.wg = new(sync.WaitGroup)
 		client.SetOffset("3")
 		Convey("When a new message is published from the cache broker", func() {
@@ -212,7 +231,7 @@ func TestCallCacheServiceWithProvidedOffsetIfSetOffsetInvoked(t *testing.T) {
 			Convey("Then the message should be forwarded to the broker", func() {
 				So(status.Err, ShouldBeNil)
 				So(status.Code, ShouldEqual, 200)
-				So(getter.AssertCalled(t, "Get", "baseurl/path?timepoint=3"), ShouldBeTrue)
+				So(getter.AssertCalled(t, "Do", expectedRequest), ShouldBeTrue)
 				So(publisher.AssertCalled(t, "Publish", "Test Data \n"), ShouldBeTrue)
 			})
 		})
@@ -232,8 +251,8 @@ func (b *mockBroker) Unsubscribe(subscription chan string) error {
 	return b.Called(subscription).Error(0)
 }
 
-func (c *mockHttpClient) Get(url string) (resp *http.Response, err error) {
-	args := c.Called(url)
+func (c *mockHttpClient) Do(req *http.Request) (resp *http.Response, err error) {
+	args := c.Called(req)
 	return args.Get(0).(*http.Response), args.Error(1)
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -17,6 +17,7 @@ type Config struct {
 	CacheBrokerURL       string      `env:"CACHE_BROKER_URL"             flag:"cache-broker-url"       flagDesc:"Cache broker url"`
 	OfficersEndpointFlag bool        `env:"OFFICERS_ENDPOINT_ENABLED"    flag:"officers-endpoint-flag" flagDesc:"Flag to enable/disable the Officers stream"`
 	PSCsEndpointFlag     bool        `env:"PSCS_ENDPOINT_ENABLED"        flag:"pscs-endpoint-flag"     flagDesc:"Flag to enable/disable the PSCs stream"`
+	ApiKey               string      `env:"CHS_API_KEY" flag:"api-key" flagDesc:"API key used to connect to cache service"`
 }
 
 // ServiceConfig returns a ServiceConfig interface for Config.

--- a/factory/factory.go
+++ b/factory/factory.go
@@ -25,7 +25,7 @@ type RunnablePublisher interface {
 }
 
 type ClientGettable interface {
-	GetClient(baseurl string, path string, publisher client.Publishable, logger logger.Logger) Connectable
+	GetClient(baseurl string, path string, token string, publisher client.Publishable, logger logger.Logger) Connectable
 }
 
 type PublisherGettable interface {
@@ -98,8 +98,8 @@ type Publisher struct {
 	data chan string
 }
 
-func (c *ClientFactory) GetClient(baseurl string, path string, publisher client.Publishable, logger logger.Logger) Connectable {
-	return client.NewClient(baseurl, path, publisher, http.DefaultClient, logger)
+func (c *ClientFactory) GetClient(baseurl string, path string, token string, publisher client.Publishable, logger logger.Logger) Connectable {
+	return client.NewClient(baseurl, path, token, publisher, http.DefaultClient, logger)
 }
 
 func (t *TimerFactory) GetTimer(duration time.Duration) Elapseable {

--- a/factory/factory_test.go
+++ b/factory/factory_test.go
@@ -14,7 +14,7 @@ func TestGetClientReturnsNewClientInstance(t *testing.T) {
 		publisher := &Publisher{}
 		loggerInstance := &logger.LoggerImpl{}
 		Convey("When a new client instance is obtained", func() {
-			actual := factory.GetClient("baseurl", "/path", publisher, loggerInstance)
+			actual := factory.GetClient("baseurl", "/path", "token", publisher, loggerInstance)
 			Convey("Then a client instance constructed from the given params should be returned", func() {
 				So(actual, ShouldNotBeNil)
 			})

--- a/handlers/stream.go
+++ b/handlers/stream.go
@@ -23,13 +23,14 @@ type Streaming struct {
 	TimerFactory      factory.TimestampGeneratable
 	ClientFactory     factory.ClientGettable
 	PublisherFactory  factory.PublisherGettable
+	ApiKey            string
 }
 
 // AddStream sets up the routing for the particular stream type
 func (st Streaming) AddStream(router *pat.Router, backendPath string, route string, streamName string) {
 	broker := broker.NewBroker() //incoming messages
 	//connect to cache-broker
-	client2 := st.ClientFactory.GetClient(st.CacheBrokerURL, backendPath, broker, st.Logger)
+	client2 := st.ClientFactory.GetClient(st.CacheBrokerURL, backendPath, st.ApiKey, broker, st.Logger)
 	client2.Connect()
 	go broker.Run()
 
@@ -57,7 +58,7 @@ func (st Streaming) ProcessHTTP(writer http.ResponseWriter, request *http.Reques
 
 	st.Logger.Info("Handling offset")
 	if route != "" {
-		serviceClient = st.ClientFactory.GetClient(st.CacheBrokerURL, route, broker, st.Logger)
+		serviceClient = st.ClientFactory.GetClient(st.CacheBrokerURL, route, st.ApiKey, broker, st.Logger)
 		serviceClient.SetOffset(request.URL.Query().Get("timepoint"))
 		serviceClient.Connect()
 	}

--- a/handlers/stream_test.go
+++ b/handlers/stream_test.go
@@ -283,7 +283,7 @@ func TestOffsetSpecified(t *testing.T) {
 		serviceClient.On("SetOffset", mock.Anything).Return()
 
 		clientFactory := &mockClientFactory{}
-		clientFactory.On("GetClient", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(serviceClient)
+		clientFactory.On("GetClient", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(serviceClient)
 
 		requestTimer := &mockTimer{}
 		requestTimer.On("Start").Return()
@@ -311,6 +311,7 @@ func TestOffsetSpecified(t *testing.T) {
 			TimerFactory:      timerFactory,
 			Logger:            logger.NewLogger(),
 			wg:                new(sync.WaitGroup),
+			ApiKey:            "key",
 		}
 		testStream.wg.Add(1)
 
@@ -322,7 +323,7 @@ func TestOffsetSpecified(t *testing.T) {
 			Convey("Then the message should be pushed to the user", func() {
 				So(w.Code, ShouldEqual, 200)
 				So(w.Body.Bytes(), ShouldResemble, []byte("hello"))
-				So(clientFactory.AssertCalled(t, "GetClient", "baseurl", "/filings", publisher, mock.Anything), ShouldBeTrue)
+				So(clientFactory.AssertCalled(t, "GetClient", "baseurl", "/filings", "key", publisher, mock.Anything), ShouldBeTrue)
 				So(serviceClient.AssertCalled(t, "SetOffset", "1"), ShouldBeTrue)
 				So(serviceClient.AssertCalled(t, "Connect"), ShouldBeTrue)
 				So(publisher.AssertCalled(t, "Subscribe"), ShouldBeTrue)
@@ -351,7 +352,7 @@ func TestCloseClientWhenUserDisconnects(t *testing.T) {
 		serviceClient.On("Close").Return()
 
 		clientFactory := &mockClientFactory{}
-		clientFactory.On("GetClient", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(serviceClient)
+		clientFactory.On("GetClient", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(serviceClient)
 
 		requestTimer := &mockTimer{}
 		requestTimer.On("Start").Return()
@@ -382,6 +383,7 @@ func TestCloseClientWhenUserDisconnects(t *testing.T) {
 			TimerFactory:      timerFactory,
 			Logger:            logger.NewLogger(),
 			wg:                new(sync.WaitGroup),
+			ApiKey:            "key",
 		}
 		testStream.wg.Add(1)
 
@@ -392,7 +394,7 @@ func TestCloseClientWhenUserDisconnects(t *testing.T) {
 			testStream.wg.Wait()
 			Convey("Then the user should be unsubscribed from the broker and the client should be closed", func() {
 				So(w.Code, ShouldEqual, 200)
-				So(clientFactory.AssertCalled(t, "GetClient", "baseurl", "/filings", publisher, mock.Anything), ShouldBeTrue)
+				So(clientFactory.AssertCalled(t, "GetClient", "baseurl", "/filings", "key", publisher, mock.Anything), ShouldBeTrue)
 				So(serviceClient.AssertCalled(t, "SetOffset", "1"), ShouldBeTrue)
 				So(serviceClient.AssertCalled(t, "Connect"), ShouldBeTrue)
 				So(publisher.AssertCalled(t, "Subscribe"), ShouldBeTrue)
@@ -425,7 +427,7 @@ func TestCloseClientIfConnectionExpired(t *testing.T) {
 		serviceClient.On("Close").Return()
 
 		clientFactory := &mockClientFactory{}
-		clientFactory.On("GetClient", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(serviceClient)
+		clientFactory.On("GetClient", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(serviceClient)
 
 		context := &mockContext{}
 		context.On("Done").Return(connectionClosed)
@@ -457,6 +459,7 @@ func TestCloseClientIfConnectionExpired(t *testing.T) {
 			TimerFactory:      timerFactory,
 			Logger:            logger.NewLogger(),
 			wg:                new(sync.WaitGroup),
+			ApiKey:            "key",
 		}
 		testStream.wg.Add(1)
 
@@ -467,7 +470,7 @@ func TestCloseClientIfConnectionExpired(t *testing.T) {
 			testStream.wg.Wait()
 			Convey("Then the user should be unsubscribed from the broker and the client should be closed", func() {
 				So(w.Code, ShouldEqual, 200)
-				So(clientFactory.AssertCalled(t, "GetClient", "baseurl", "/filings", publisher, mock.Anything), ShouldBeTrue)
+				So(clientFactory.AssertCalled(t, "GetClient", "baseurl", "/filings", "key", publisher, mock.Anything), ShouldBeTrue)
 				So(serviceClient.AssertCalled(t, "SetOffset", "1"), ShouldBeTrue)
 				So(serviceClient.AssertCalled(t, "Connect"), ShouldBeTrue)
 				So(publisher.AssertCalled(t, "Subscribe"), ShouldBeTrue)
@@ -529,8 +532,8 @@ func (b *mockBroker) Publish(msg string) {
 	b.Called(msg)
 }
 
-func (c *mockClientFactory) GetClient(baseurl string, path string, publisher client.Publishable, logger logger.Logger) factory.Connectable {
-	return c.Called(baseurl, path, publisher, logger).Get(0).(factory.Connectable)
+func (c *mockClientFactory) GetClient(baseurl string, path string, key string, publisher client.Publishable, logger logger.Logger) factory.Connectable {
+	return c.Called(baseurl, path, key, publisher, logger).Get(0).(factory.Connectable)
 }
 
 func (c *mockClient) Connect() *client.ResponseStatus {

--- a/main.go
+++ b/main.go
@@ -57,6 +57,7 @@ func main() {
 		ClientFactory:     &factory.ClientFactory{},
 		PublisherFactory:  &factory.PublisherFactory{},
 		TimerFactory:      &factory.TimerFactory{},
+		ApiKey:            cfg.ApiKey,
 	}
 
 	//Get stream enabled flag values from config


### PR DESCRIPTION
* Requests to cache service must now be authenticated.